### PR TITLE
FIX: config for `cherry-ui-elements` in `cherry-post-meta` module

### DIFF
--- a/modules/cherry-post-meta/cherry-post-meta.php
+++ b/modules/cherry-post-meta/cherry-post-meta.php
@@ -132,7 +132,7 @@ if ( ! class_exists( 'Cherry_Post_Meta' ) ) {
 
 			array_walk( $this->args['fields'], array( $this, 'set_field_types' ) );
 
-			$this->ui_builder = $this->core->init_module( 'cherry-ui-elements', $this->field_types );
+			$this->ui_builder = $this->core->init_module( 'cherry-ui-elements', array( 'ui_elements' => $this->field_types ) );
 
 			return true;
 		}
@@ -303,7 +303,7 @@ if ( ! class_exists( 'Cherry_Post_Meta' ) ) {
 		 */
 		public function set_field_types( $field, $id ) {
 
-			if ( is_array( $field ) || ! isset( $field['type'] ) ) {
+			if ( ! is_array( $field ) || ! isset( $field['type'] ) ) {
 				return false;
 			}
 


### PR DESCRIPTION
Срабатывала инициализация для всех UI-элементов, вне зависимости от нужных элементов для метабокса.
