### PR TITLE
FIX: `base_url` method

### DIFF
--- a/cherry-core.php
+++ b/cherry-core.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Class Cherry Core
- * Version: 1.1.0
+ * Version: 1.1.1
  *
  * @package    Cherry_Framework
  * @subpackage Class
@@ -405,8 +405,8 @@ if ( ! class_exists( 'Cherry_Core' ) ) {
 			if ( 0 === strpos( $module_path, $plugin_dir ) ) {
 				$url = plugin_dir_url( $module_path );
 			} else if ( false !== strpos( $module_path, $theme_dir ) ) {
-				$explode = explode( $theme_dir, $module_dir, 2 );
-				$url     = get_stylesheet_directory_uri() . $explode[1];
+				$explode = explode( $theme_dir, $module_dir );
+				$url     = get_stylesheet_directory_uri() . end( $explode );
 			} else {
 				$site_url = site_url();
 				$abs_path = wp_normalize_path( ABSPATH );


### PR DESCRIPTION
Bug with retrieving the absolute URL. 
e.g.:
- path to wp-core-- \wamp\www`\themes\foo\`
- path to wp-theme -- \wamp\www`\themes\foo\`wp-content`\themes\foo\`
